### PR TITLE
fix issue 5

### DIFF
--- a/example/lib/list_slidable.dart
+++ b/example/lib/list_slidable.dart
@@ -71,6 +71,7 @@ class _SlidableListTileState extends State<SlidableListTile> {
       controller: _slideController,
       maxSlideThreshold: 0.8,
       axis: Axis.horizontal,
+      preActionLayout: ActionLayout.spaceEvenly(ActionMotion.drawer),
       onSlideStart: () {
         print("onSlideStart: ${widget.index}");
       },
@@ -80,8 +81,9 @@ class _SlidableListTileState extends State<SlidableListTile> {
             _slideController.preActionController?.toggle(0);
           },
           style: TextButton.styleFrom(
-            backgroundColor: Colors.greenAccent,
-            shape: const RoundedRectangleBorder(),
+            // backgroundColor: Colors.greenAccent,
+            // shape: const RoundedRectangleBorder(),
+            side: const BorderSide(color: Colors.black),
           ),
           child: const Text("Archive"),
         ),
@@ -93,12 +95,13 @@ class _SlidableListTileState extends State<SlidableListTile> {
               _slideController.dismiss();
               widget.onDeleted?.call();
             } else {
-              _slideController.expand(0);
+              _slideController.expand(1);
             }
           },
           style: TextButton.styleFrom(
             backgroundColor: Colors.redAccent,
-            shape: const RoundedRectangleBorder(),
+            // shape: const RoundedRectangleBorder(),
+            side: const BorderSide(color: Colors.black),
           ),
           child: const Text("Delete"),
         ),
@@ -107,9 +110,13 @@ class _SlidableListTileState extends State<SlidableListTile> {
         onPressed: () {
           _slideController.dismiss();
         },
+
+        ///! TextButton padding may cause the visual glitch of the action items compared to the main child
+        ///! depending on the platform, you may need to adjust the padding of the main child
         style: TextButton.styleFrom(
           backgroundColor: Colors.white,
-          shape: const RoundedRectangleBorder(),
+          // tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          // shape: const RoundedRectangleBorder(),
           side: const BorderSide(color: Colors.black),
         ),
         child: Text(widget.title),

--- a/example/lib/sized_slidable.dart
+++ b/example/lib/sized_slidable.dart
@@ -31,6 +31,7 @@ class _SizedSlidableExampleState extends State<SizedSlidableExample> {
           controller: _slideController,
           maxSlideThreshold: 0.8,
           axis: Axis.horizontal,
+          preActionLayout: ActionLayout.flex(),
           preActions: [
             TextButton(
               onPressed: () {

--- a/lib/delegates/action_layout_delegate.dart
+++ b/lib/delegates/action_layout_delegate.dart
@@ -27,7 +27,7 @@ abstract class ActionLayoutDelegate {
     double ratio = 1.0,
     required Axis axis,
   }) {
-    assert(!size.isEmpty && childCount > 0);
+    assert(childCount > 0);
 
     final sizedConstraints = getSizedConstraints(
       size: size,
@@ -40,7 +40,9 @@ abstract class ActionLayoutDelegate {
     int index = 0;
 
     while (current != null) {
-      current.layout(sizedConstraints.constraints[index], parentUsesSize: true);
+      current.layout(sizedConstraints.constraints[index],
+          parentUsesSize: false);
+
       final parentData = current.parentData as SlideActionBoxData;
 
       parentData.offset = getRelativeOffset(
@@ -164,7 +166,8 @@ class _SpaceEvenlyLayoutDelegate extends ActionLayoutDelegate {
     required Axis axis,
     required int childCount,
   }) {
-    assert(!size.isEmpty && childCount > 0);
+    // assert(!size.isEmpty && childCount > 0);
+    assert(childCount > 0);
 
     final averageWidth = size.width / childCount;
     final averageHeight = size.height / childCount;
@@ -181,21 +184,27 @@ class _SpaceEvenlyLayoutDelegate extends ActionLayoutDelegate {
 
       switch (axis) {
         case Axis.horizontal:
+          final width = indexExpanded
+              ? averageWidth * expandedRatio
+              : averageWidth * unExpandedRatio;
+          final height = width != 0 ? size.height : 0.0;
+
           final indexConstraints = BoxConstraints.tightFor(
-            width: indexExpanded
-                ? averageWidth * expandedRatio
-                : averageWidth * unExpandedRatio,
-            height: size.height,
+            width: width,
+            height: height,
           );
           remainWidth -= indexConstraints.maxWidth;
           constraints.add(indexConstraints);
           break;
         case Axis.vertical:
+          final height = indexExpanded
+              ? averageHeight * expandedRatio
+              : averageHeight * unExpandedRatio;
+
+          final width = height != 0 ? size.width : 0.0;
           final indexConstraints = BoxConstraints.tightFor(
-            width: size.width,
-            height: indexExpanded
-                ? averageHeight * expandedRatio
-                : averageHeight * unExpandedRatio,
+            width: width,
+            height: height,
           );
           remainHeight -= indexConstraints.maxHeight;
           constraints.add(indexConstraints);
@@ -234,7 +243,8 @@ class _FlexLayoutDelegate extends ActionLayoutDelegate {
     double ratio = 1.0,
     required Axis axis,
   }) {
-    assert(!size.isEmpty && childCount > 0);
+    assert(childCount > 0);
+
     flexes.clear();
     RenderBox? current = child;
 
@@ -280,22 +290,27 @@ class _FlexLayoutDelegate extends ActionLayoutDelegate {
 
       switch (axis) {
         case Axis.horizontal:
+          final width = indexExpanded
+              ? widthForEachFlex * flex * expandedRatio
+              : widthForEachFlex * flex * unExpandedRatio;
+
+          final height = width != 0 ? size.height : 0.0;
           final indexConstraints = BoxConstraints.tightFor(
-            width: indexExpanded
-                ? widthForEachFlex * flex * expandedRatio
-                : widthForEachFlex * flex * unExpandedRatio,
-            height: size.height,
+            width: width,
+            height: height,
           );
           remainWidth -= indexConstraints.maxWidth;
           constraints.add(indexConstraints);
           break;
 
         case Axis.vertical:
+          final height = indexExpanded
+              ? heightForEachFlex * flex * expandedRatio
+              : heightForEachFlex * flex * unExpandedRatio;
+          final width = height != 0 ? size.width : 0.0;
           final indexConstraints = BoxConstraints.tightFor(
-            width: size.width,
-            height: indexExpanded
-                ? heightForEachFlex * flex * expandedRatio
-                : heightForEachFlex * flex * unExpandedRatio,
+            width: width,
+            height: height,
           );
           remainHeight -= indexConstraints.maxHeight;
           constraints.add(indexConstraints);

--- a/lib/renders/slide_action_render.dart
+++ b/lib/renders/slide_action_render.dart
@@ -134,7 +134,7 @@ class RenderSlideAction extends RenderBox
     final child = firstChild;
     final position = (parentData as SlidableBoxData).position!;
 
-    if (child == null || size.isEmpty) {
+    if (child == null) {
       return;
     }
 
@@ -156,6 +156,7 @@ class RenderSlideAction extends RenderBox
   @override
   void paint(PaintingContext context, Offset offset) {
     if (size.isEmpty) return;
+
     context.pushClipRect(
       needsCompositing,
       offset,


### PR DESCRIPTION
When the slide panel is closed/dismissed, the pre and post actions will not be laid out.

However, their elements have been mounted but cannot trigger `markNeedsSematicsUpdate()`, as they are never laid out once.

See https://github.com/SimonWang9610/flutter_slidable_panel/issues/5